### PR TITLE
Add daily and weekly summaries, fix 1970 dates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *png
 *ipynb
 *json
+DB_scripts/CSV
+log*txt
+__pycache__

--- a/DB_scripts/DailySummary.py
+++ b/DB_scripts/DailySummary.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python3
+
+import pandas as pd
+import glob
+import datetime
+
+import os
+from slack_sdk import WebClient
+
+csv_path = '/asic/projects/E/ECON_PROD_TESTING/dnoonan/econ_json_parsing/DB_scripts/CSV'
+f_D = glob.glob(f'{csv_path}/econdCSV/econd_chip_test_results_{datetime.datetime.now().year}-{datetime.datetime.now().month:02d}-{datetime.datetime.now().day:02d}_*.csv')[0]
+f_T = glob.glob(f'{csv_path}/econtCSV/econt_chip_test_results_{datetime.datetime.now().year}-{datetime.datetime.now().month:02d}-{datetime.datetime.now().day:02d}_*.csv')[0]
+
+
+df_D = pd.read_csv(f_D,index_col=0).sort_index()
+df_T = pd.read_csv(f_T,index_col=0).sort_index()
+df_D.Timestamp = pd.to_datetime(df_D.Timestamp)
+df_T.Timestamp = pd.to_datetime(df_T.Timestamp)
+df_D['Pass'] = df_D['Pass/Fail']=='Pass'
+df_D['Fail'] = df_D['Pass/Fail']=='Fail'
+df_T['Pass'] = df_T['Pass/Fail']=='Pass'
+df_T['Fail'] = df_T['Pass/Fail']=='Fail'
+by_week_D=df_D.groupby(pd.Grouper(key='Timestamp', freq='3h'))
+by_week_T=df_T.groupby(pd.Grouper(key='Timestamp', freq='3h'))
+
+
+summary_D = by_week_D.count()[['Pass/Fail']]
+summary_D.columns = ['Total']
+summary_D['Passing'] = by_week_D.sum()['Pass']
+summary_D['Failing'] = by_week_D.sum()['Fail']
+
+summary_T = by_week_T.count()[['Pass/Fail']]
+summary_T.columns = ['Total']
+summary_T['Passing'] = by_week_T.sum()['Pass']
+summary_T['Failing'] = by_week_T.sum()['Fail']
+
+summary = summary_D.merge(summary_T,how='outer',left_index=True,right_index=True,suffixes=('_ECOND','_ECONT')).fillna(0).astype(int)
+
+today = datetime.datetime.now()
+yesterday=(today-datetime.timedelta(days=1))
+yesterdaySummary = summary[(summary.index>yesterday.strftime('%Y-%m-%d 08')) & (summary.index<today.strftime('%Y-%m-%d 09'))]
+
+total_row = yesterdaySummary.sum()
+totals=pd.DataFrame(total_row.rename('Total')).T
+yesterdaySummary = pd.concat([yesterdaySummary,totals])
+print(yesterdaySummary)
+
+report = f'```\n{yesterdaySummary.to_string()}\n```'
+
+token = os.environ.get("SLACK_TOKEN")
+if token is None:
+    print("SLACK_TOKEN is not defined as environment variable, skipping send")
+else:
+    client = WebClient(token=token)
+
+    result = client.chat_postMessage(
+        channel = "cms-econ-asic",
+        text = report,
+        username = "Bot User")
+
+

--- a/DB_scripts/WeeklySummary.py
+++ b/DB_scripts/WeeklySummary.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python3
+
+import pandas as pd
+import glob
+import datetime
+
+import os
+from slack_sdk import WebClient
+
+csv_path = '/asic/projects/E/ECON_PROD_TESTING/dnoonan/econ_json_parsing/DB_scripts/CSV'
+f_D = glob.glob(f'{csv_path}/econdCSV/econd_chip_test_results_{datetime.datetime.now().year}-{datetime.datetime.now().month:02d}-{datetime.datetime.now().day:02d}_*.csv')[0]
+f_T = glob.glob(f'{csv_path}/econtCSV/econt_chip_test_results_{datetime.datetime.now().year}-{datetime.datetime.now().month:02d}-{datetime.datetime.now().day:02d}_*.csv')[0]
+
+
+df_D = pd.read_csv(f_D,index_col=0).sort_index()
+df_T = pd.read_csv(f_T,index_col=0).sort_index()
+df_D.Timestamp = pd.to_datetime(df_D.Timestamp)
+df_T.Timestamp = pd.to_datetime(df_T.Timestamp)
+df_D['Pass'] = df_D['Pass/Fail']=='Pass'
+df_D['Fail'] = df_D['Pass/Fail']=='Fail'
+df_T['Pass'] = df_T['Pass/Fail']=='Pass'
+df_T['Fail'] = df_T['Pass/Fail']=='Fail'
+by_week_D=df_D.groupby(pd.Grouper(key='Timestamp', freq='W'))
+by_week_T=df_T.groupby(pd.Grouper(key='Timestamp', freq='W'))
+
+
+summary_D = by_week_D.count()[['Pass/Fail']]
+summary_D.columns = ['Total']
+summary_D['Passing'] = by_week_D.sum()['Pass']
+summary_D['Failing'] = by_week_D.sum()['Fail']
+
+summary_T = by_week_T.count()[['Pass/Fail']]
+summary_T.columns = ['Total']
+summary_T['Passing'] = by_week_T.sum()['Pass']
+summary_T['Failing'] = by_week_T.sum()['Fail']
+
+summary = summary_D.merge(summary_T,how='outer',left_index=True,right_index=True,suffixes=('_ECOND','_ECONT')).fillna(0).astype(int)
+
+today = datetime.datetime.now()
+lastMonth=(today-datetime.timedelta(days=28))
+prior = summary[summary.index<lastMonth.strftime('%Y-%m-%d')]
+prior_row = prior.sum()
+prior = pd.DataFrame(prior_row.rename("Prior")).T
+monthlySummary = summary[summary.index>lastMonth.strftime('%Y-%m-%d 08')]
+
+monthlySummary = pd.concat([prior,monthlySummary])
+
+total_row = monthlySummary.sum()
+totals=pd.DataFrame(total_row.rename('Total')).T
+monthlySummary = pd.concat([monthlySummary,totals])
+print(monthlySummary)
+
+report = f'```\n{monthlySummary.to_string()}\n```'
+
+token = os.environ.get("SLACK_TOKEN")
+if token is None:
+    print("SLACK_TOKEN is not defined as environment variable, skipping send")
+else:
+    client = WebClient(token=token)
+
+    result = client.chat_postMessage(
+        channel = "cms-econ-asic",
+        text = report,
+        username = "Bot User")
+
+

--- a/DB_scripts/create_DailySummary.sh
+++ b/DB_scripts/create_DailySummary.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+. /fasic_home/dnoonan/.slack_token
+
+cd /fasic_home/dnoonan/WD_ECON_Testing/dnoonan/econ_json_parsing/DB_scripts/
+
+python /fasic_home/dnoonan/WD_ECON_Testing/dnoonan/econ_json_parsing/DB_scripts/makeCSVECOND.py
+python /fasic_home/dnoonan/WD_ECON_Testing/dnoonan/econ_json_parsing/DB_scripts/makeCSVECONT.py
+python /fasic_home/dnoonan/WD_ECON_Testing/dnoonan/econ_json_parsing/DB_scripts/DailySummary.py

--- a/DB_scripts/create_WeeklySummary.sh
+++ b/DB_scripts/create_WeeklySummary.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+. /fasic_home/dnoonan/.slack_token
+
+cd /fasic_home/dnoonan/WD_ECON_Testing/dnoonan/econ_json_parsing/DB_scripts/
+
+python /fasic_home/dnoonan/WD_ECON_Testing/dnoonan/econ_json_parsing/DB_scripts/WeeklySummary.py

--- a/DB_scripts/makeCSVECOND.py
+++ b/DB_scripts/makeCSVECOND.py
@@ -124,7 +124,8 @@ for i, volt in enumerate(voltages):
 outcomes, chipNums, Timestamp, IP = db.getPassFailResults()
 socket = replaced_arr = ['B' if x == '46' else 'A' for x in IP]
 updatedTimestamp = [
-    date.replace(year=2025) if date.year == 1970 else date for date in Timestamp
+    datetime.datetime.strptime('2024-11-01','%Y-%m-%d') if date.year==1970 else date for date in Timestamp
+#    date.replace(year=2025) if date.year == 1970 else date for date in Timestamp
 ]
 
 ## get streamCompare results

--- a/DB_scripts/makeCSVECONT.py
+++ b/DB_scripts/makeCSVECONT.py
@@ -125,7 +125,8 @@ print('Gathering all data')
 outcomes, chipNums, Timestamp, IP = db.getPassFailResults(econType='ECONT')
 socket = replaced_arr = ['B' if x == '46' else 'A' for x in IP]
 updatedTimestamp = [
-    date.replace(year=2025) if date.year == 1970 else date for date in Timestamp
+    datetime.datetime.strptime('2024-11-01','%Y-%m-%d') if date.year==1970 else date for date in Timestamp
+    # date.replace(year=2025) if date.year == 1970 else date for date in Timestamp
 ]
 
 ## get current reading and temperature results


### PR DESCRIPTION
Adds scripts for producing summaries of ECON-D and ECON-T yields every day and every week.

Fixes issue where all dates from hexacontrollers where date wasn't set was being re-assigned to valid timestamps (moved to January of 2025).  This was causing confusion about when the data was actually taken, because these times also had much higher temperatures, which is something we had fixed before January.